### PR TITLE
Fix build by excluding examples

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+examples/

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,8 +12,7 @@
   "include": [
     "src/**/*.ts",
     "test/**/*.ts",
-    "examples/**/*.ts",
     "vitest.config.ts"
   ],
-  "exclude": ["node_modules", "dist"]
-} 
+  "exclude": ["node_modules", "dist", "examples"]
+}


### PR DESCRIPTION
## Summary
- exclude example code from TypeScript build
- ignore examples for ESLint

## Testing
- `npm run build`
- `npm test`
- `npx eslint . --ext .ts`

------
https://chatgpt.com/codex/tasks/task_e_68421c425b34832787363dc9034196c2