### PR TITLE
Update coverage script and CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
         with:
           node-version: 18.x
       - run: npm ci
-      - run: npx vitest run --coverage
+      - run: npm run coverage
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
         with:

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,8 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 100%
+    patch:
+      default:
+        target: 100%

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "test": "vitest run",
     "lint": "eslint . --ext .ts",
-    "coverage": "c8 vitest run",
+    "coverage": "c8 vitest run && c8 check-coverage --branches 100 --functions 100 --lines 100 --statements 100",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
     "build": "tsc -p tsconfig.build.json",
     "prepublishOnly": "npm run lint && npm run test && npm run build"


### PR DESCRIPTION
## Summary
- check coverage thresholds in `npm run coverage`
- configure Codecov to require 100% project and patch coverage
- update CI workflow to run `npm run coverage`

## Testing
- `npm ci`
- `npm run coverage` *(fails: coverage 0%)*
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_6844c692494883279263d15b0f0f738b