### PR TITLE
Lazy initialization for default cache handler

### DIFF
--- a/src/cache/fetchWithCache.ts
+++ b/src/cache/fetchWithCache.ts
@@ -18,15 +18,20 @@
  * );
  * ```
  */
-import type { CacheFetchOptions } from '../types';
+import type { CacheFetchOptions, CacheHandler } from '../types';
 import { createCacheHandler } from './createCacheHandler';
 import { createDefaultBackend } from '../backends';
 
-// Create a singleton cache handler with default Redis backend
-const defaultHandler = createCacheHandler({
-  backend: createDefaultBackend(),
-  prefix: 'next-cachex',
-});
+// Lazily create the default cache handler when first accessed
+let defaultHandler: CacheHandler<unknown> | undefined;
+export function getDefaultHandler() {
+  if (!defaultHandler)
+    defaultHandler = createCacheHandler({
+      backend: createDefaultBackend(),
+      prefix: 'next-cachex',
+    });
+  return defaultHandler;
+}
 
 export async function fetchWithCache<T>(
   key: string,
@@ -44,8 +49,8 @@ export async function fetchWithCache<T>(
   }
   
   // Use the default handler
-  return defaultHandler.fetch(key, fetcher, options);
+  return getDefaultHandler().fetch(key, fetcher, options);
 }
 
 // Export the default handler for convenience
-export const cacheHandler = defaultHandler; 
+export { getDefaultHandler as cacheHandler };


### PR DESCRIPTION
## Summary
- lazily create the default handler when first accessed
- call `getDefaultHandler()` inside `fetchWithCache`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6844c6a213808327b55f763c6553a811