### PR TITLE
⚡ Bolt: Precompute static prefix to optimize getFullKey performance

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-04-24 - Precomputing Static Prefixes on Hot Paths
+**Learning:** In Node.js, dynamic array allocation (`[]`), array methods like `.filter(Boolean)`, and `.join(':')` inside a hot path (like cache key generation) introduce unnecessary CPU overhead and memory allocation pressure. This is a common performance anti-pattern.
+**Action:** Always precompute static segments of strings outside the function scope (e.g. at initialization). Use simple string concatenation or template literals (`${prefix}${key}`) on the hot path to construct keys efficiently.

--- a/src/cache/createCacheHandler.ts
+++ b/src/cache/createCacheHandler.ts
@@ -61,12 +61,16 @@ export function createCacheHandler<T = unknown>(options: CacheHandlerOptions<T>)
   const l1Cache = new Map<string, { value: unknown; expiresAt: number }>();
   const L1_CACHE_TTL = 1000; // 1 second TTL for L1 cache
 
+  // Precompute base prefix to avoid array allocations, .filter(), and .join() on every fetch (hot path)
+  const baseParts = [prefix, version].filter(Boolean);
+  const basePrefix = baseParts.length > 0 ? `${baseParts.join(':')}:` : '';
+
   /**
    * Get the fully qualified key with prefix and version
    */
   const getFullKey = (key: string): string => {
-    const parts = [prefix, version, key].filter(Boolean);
-    return parts.join(':');
+    // Check for empty key edge case to match original .filter(Boolean) behavior
+    return key ? `${basePrefix}${key}` : baseParts.join(':');
   };
 
   /**


### PR DESCRIPTION
💡 What: Precomputed the base prefix inside `createCacheHandler` and simplified `getFullKey` to use basic string concatenation instead of dynamic array allocation, `.filter()`, and `.join()`.

🎯 Why: `getFullKey` is on the absolute hottest path (called on every cache `fetch`). Continuously allocating arrays and iterating through them for statically known values (prefix, version) generates unnecessary CPU overhead and V8 garbage collection pressure.

📊 Impact: Expected to decrease CPU time and memory allocation overhead per cache lookup, yielding more consistent latency at scale.

🔬 Measurement: Verify correctness by ensuring unit test suite `npm run test` passes (specifically `createCacheHandler.test.ts`). You can profile memory allocations during load testing to confirm reduced garbage collection sweeps.

---
*PR created automatically by Jules for task [9861965848047480127](https://jules.google.com/task/9861965848047480127) started by @suranig*