### PR TITLE
⚡ Bolt: OOM protection for L1 cache & fetchOptions allocation optimization

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2024-05-18 - Optimize getFullKey to avoid dynamic array allocation
 **Learning:** In Node.js, dynamically creating arrays, filtering them, and joining them on hot paths (like cache key generation) can be significantly slower than precomputing static prefixes and using simple string concatenation or template literals. A micro-benchmark showed a ~94% improvement in execution time for key generation.
 **Action:** Always precompute static prefixes outside of hot path functions and use template literals/string concatenation to minimize CPU overhead and memory pressure.
+
+## 2024-05-18 - Safe Map Key Eviction with Empty Strings
+**Learning:** When manually implementing FIFO cache eviction using `map.keys().next().value`, a truthy check `if (oldestKey)` fails to evict an item if its key is an empty string `""`. This causes the cache to grow unbounded if empty strings are valid keys.
+**Action:** Always use strict undefined checks `if (oldestKey !== undefined)` when checking the presence of a map key or value to correctly handle falsy, but valid, values.

--- a/src/cache/createCacheHandler.ts
+++ b/src/cache/createCacheHandler.ts
@@ -60,6 +60,21 @@ export function createCacheHandler<T = unknown>(options: CacheHandlerOptions<T>)
   // Simple in-memory cache for frequently accessed keys (L1 cache)
   const l1Cache = new Map<string, { value: unknown; expiresAt: number }>();
   const L1_CACHE_TTL = 1000; // 1 second TTL for L1 cache
+  const MAX_L1_CACHE_SIZE = 1000; // Maximum number of items in L1 cache
+
+  /**
+   * Helper to set L1 cache value with FIFO eviction if max size is exceeded
+   */
+  const setL1Cache = (key: string, value: unknown) => {
+    if (l1Cache.size >= MAX_L1_CACHE_SIZE && !l1Cache.has(key)) {
+      // FIFO eviction: remove the oldest item
+      const oldestKey = l1Cache.keys().next().value;
+      if (oldestKey !== undefined) {
+        l1Cache.delete(oldestKey);
+      }
+    }
+    l1Cache.set(key, { value, expiresAt: Date.now() + L1_CACHE_TTL });
+  };
 
   // Precompute prefix string for faster key generation
   const keyPrefix = [prefix, version].filter(Boolean).join(':');
@@ -81,12 +96,12 @@ export function createCacheHandler<T = unknown>(options: CacheHandlerOptions<T>)
     options?: CacheFetchOptions,
   ): Promise<R> => {
     const fullKey = getFullKey(key);
-    const fetchOptions = { ...DEFAULT_FETCH_OPTIONS, ...options };
+    const fetchOptions = options ? { ...DEFAULT_FETCH_OPTIONS, ...options } : DEFAULT_FETCH_OPTIONS;
 
     // Try to get from L1 cache first
     const l1Item = l1Cache.get(fullKey);
     if (l1Item && l1Item.expiresAt > Date.now()) {
-      logger.log({ type: 'HIT', key: fullKey });
+      logger.log({ type: 'HIT', key: fullKey }); // Note: tests assume L1 hit logs HIT
       return l1Item.value as R;
     }
 
@@ -95,10 +110,7 @@ export function createCacheHandler<T = unknown>(options: CacheHandlerOptions<T>)
       const cached = (await backend.get(fullKey)) as R | undefined;
       if (cached !== undefined) {
         // Store in L1 cache for future fast access
-        l1Cache.set(fullKey, {
-          value: cached,
-          expiresAt: Date.now() + L1_CACHE_TTL,
-        });
+        setL1Cache(fullKey, cached);
         logger.log({ type: 'HIT', key: fullKey });
         return cached;
       }
@@ -136,10 +148,7 @@ export function createCacheHandler<T = unknown>(options: CacheHandlerOptions<T>)
         });
 
         // Also store in L1 cache
-        l1Cache.set(fullKey, {
-          value,
-          expiresAt: Date.now() + L1_CACHE_TTL,
-        });
+        setL1Cache(fullKey, value);
 
         // If staleTtl is set, store a stale copy with longer TTL
         if (fallbackToStale && fetchOptions.staleTtl && fetchOptions.staleTtl > fetchOptions.ttl) {

--- a/test/cache/createCacheHandler.test.ts
+++ b/test/cache/createCacheHandler.test.ts
@@ -411,6 +411,56 @@ describe('createCacheHandler', () => {
     });
   });
 
+  describe('L1 cache eviction', () => {
+    it('should evict oldest item when MAX_L1_CACHE_SIZE is exceeded', async () => {
+      const evictionHandler = createCacheHandler({ backend });
+
+      // Fill cache to max limit (1000 items)
+      const MAX_L1_CACHE_SIZE = 1000;
+      for (let i = 0; i < MAX_L1_CACHE_SIZE; i++) {
+        await evictionHandler.fetch(`key-${i}`, async () => `value-${i}`);
+      }
+
+      // At this point, key-0 should still be in L1 cache (we can test it by seeing if a fetch avoids lock)
+      // but testing internal cache hit/miss is easier with logging
+      let hitLogged = false;
+      let missLogged = false;
+      const testLogger = {
+        log: (event: CacheLogEvent) => {
+          if (event.type === 'HIT' && event.key === 'key-0') hitLogged = true;
+          if (event.type === 'MISS' && event.key === 'key-0') missLogged = true;
+        }
+      };
+
+      const loggerHandler = createCacheHandler({ backend, logger: testLogger });
+
+      // Re-populate L1 cache for the new handler
+      for (let i = 0; i < MAX_L1_CACHE_SIZE; i++) {
+        await loggerHandler.fetch(`key-${i}`, async () => `value-${i}`);
+      }
+
+      // Reset hitLogged before testing L1 cache HIT
+      hitLogged = false;
+
+      // Fetch key-0, should be a HIT from L1 cache
+      await loggerHandler.fetch('key-0', async () => 'value-0');
+      expect(hitLogged).toBe(true);
+
+      hitLogged = false;
+      missLogged = false;
+
+      // Add one more item to trigger eviction of key-0
+      await loggerHandler.fetch(`key-${MAX_L1_CACHE_SIZE}`, async () => `value-${MAX_L1_CACHE_SIZE}`);
+
+      // Delete key-0 from backend to ensure L1 miss causes a full MISS
+      await backend.del('key-0');
+
+      // Fetch key-0 again, should be a MISS because it was evicted from L1 and deleted from backend
+      await loggerHandler.fetch('key-0', async () => 'value-0');
+      expect(missLogged).toBe(true);
+    });
+  });
+
   describe('edge cases', () => {
     it('should handle empty prefix and version', () => {
       const plainHandler = createCacheHandler({


### PR DESCRIPTION
💡 What: Introduced a maximum capacity (`MAX_L1_CACHE_SIZE` = 1000) for the L1 in-memory cache with a FIFO eviction strategy. Also optimized the object allocation of `fetchOptions` to avoid unnecessary object spread operations on cache fetches.

🎯 Why: The L1 `Map` cache lacked any bounds limit, allowing it to potentially grow unbounded over time and lead to memory exhaustion (OOM), which poses a DoS risk in long-running processes or on highly dynamic routes with high cache miss variance. The object spread optimization reduces unnecessary garbage collection overhead on the very hot `fetch` path.

📊 Impact: Restricts memory footprint to a strict maximum limit, ensuring stability. CPU overhead is slightly reduced per cache `fetch` call when custom options are omitted.

🔬 Measurement: Run the new L1 cache eviction tests using `npm run test` and check that the tests verify the oldest entries are purged as expected. Memory footprint can be measured and will no longer grow beyond ~1000 concurrent L1 keys.

---
*PR created automatically by Jules for task [12425408148880868313](https://jules.google.com/task/12425408148880868313) started by @suranig*