### PR TITLE
⚡ Bolt: Prevent L1 cache memory exhaustion via FIFO size limit

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2024-05-18 - Optimize getFullKey to avoid dynamic array allocation
 **Learning:** In Node.js, dynamically creating arrays, filtering them, and joining them on hot paths (like cache key generation) can be significantly slower than precomputing static prefixes and using simple string concatenation or template literals. A micro-benchmark showed a ~94% improvement in execution time for key generation.
 **Action:** Always precompute static prefixes outside of hot path functions and use template literals/string concatenation to minimize CPU overhead and memory pressure.
+## 2026-04-30 - L1 Cache Memory Exhaustion
+**Learning:** Implementing an L1 cache without a size limit exposes the application to potential Denial of Service (DoS) attacks via memory exhaustion, especially when caching numerous distinct, dynamically generated keys.
+**Action:** Always enforce a size limit (e.g., `MAX_L1_CACHE_SIZE`) and an eviction policy (e.g., FIFO) on in-memory caches to prevent memory leaks and out-of-memory errors.

--- a/src/cache/createCacheHandler.ts
+++ b/src/cache/createCacheHandler.ts
@@ -60,6 +60,23 @@ export function createCacheHandler<T = unknown>(options: CacheHandlerOptions<T>)
   // Simple in-memory cache for frequently accessed keys (L1 cache)
   const l1Cache = new Map<string, { value: unknown; expiresAt: number }>();
   const L1_CACHE_TTL = 1000; // 1 second TTL for L1 cache
+  const MAX_L1_CACHE_SIZE = 1000; // Max items to prevent memory exhaustion
+
+  /**
+   * Safely add to L1 cache enforcing size limit with FIFO eviction
+   */
+  const setL1Cache = (key: string, value: unknown) => {
+    if (l1Cache.size >= MAX_L1_CACHE_SIZE && !l1Cache.has(key)) {
+      const oldestKey = l1Cache.keys().next().value;
+      if (oldestKey !== undefined) {
+        l1Cache.delete(oldestKey);
+      }
+    }
+    l1Cache.set(key, {
+      value,
+      expiresAt: Date.now() + L1_CACHE_TTL,
+    });
+  };
 
   // Precompute prefix string for faster key generation
   const keyPrefix = [prefix, version].filter(Boolean).join(':');
@@ -95,10 +112,7 @@ export function createCacheHandler<T = unknown>(options: CacheHandlerOptions<T>)
       const cached = (await backend.get(fullKey)) as R | undefined;
       if (cached !== undefined) {
         // Store in L1 cache for future fast access
-        l1Cache.set(fullKey, {
-          value: cached,
-          expiresAt: Date.now() + L1_CACHE_TTL,
-        });
+        setL1Cache(fullKey, cached);
         logger.log({ type: 'HIT', key: fullKey });
         return cached;
       }
@@ -136,10 +150,7 @@ export function createCacheHandler<T = unknown>(options: CacheHandlerOptions<T>)
         });
 
         // Also store in L1 cache
-        l1Cache.set(fullKey, {
-          value,
-          expiresAt: Date.now() + L1_CACHE_TTL,
-        });
+        setL1Cache(fullKey, value);
 
         // If staleTtl is set, store a stale copy with longer TTL
         if (fallbackToStale && fetchOptions.staleTtl && fetchOptions.staleTtl > fetchOptions.ttl) {

--- a/test/cache/createCacheHandler.test.ts
+++ b/test/cache/createCacheHandler.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { createCacheHandler } from '../../src/cache/createCacheHandler';
 import { CacheBackend, CacheHandler, CacheTimeoutError, CacheLogEvent } from '../../src/types';
 
@@ -397,7 +397,7 @@ describe('createCacheHandler', () => {
     });
   });
 
-  describe('destroy method', () => {
+  describe('destroy method and l1Cache behavior', () => {
     it('should expose destroy method which clears the interval', () => {
       const tempHandler = createCacheHandler({ backend });
       expect(typeof tempHandler.destroy).toBe('function');
@@ -408,6 +408,34 @@ describe('createCacheHandler', () => {
           tempHandler.destroy();
         }
       }).not.toThrow();
+    });
+
+    it('should limit L1 cache size and evict oldest elements first', async () => {
+      const tempHandler = createCacheHandler({ backend });
+
+      // We will trigger 1005 requests. Since MAX_L1_CACHE_SIZE is 1000,
+      // the first 5 should be evicted from the L1 cache.
+      for (let i = 0; i < 1005; i++) {
+        await tempHandler.fetch(`key-${i}`, async () => i);
+      }
+
+      // Directly check the backend to verify that it had to hit the backend
+      // But we can't easily mock L1 cache hits vs backend hits without spying on backend.get
+      const backendSpy = vi.spyOn(backend, 'get');
+
+      // Key 0 should be evicted, so fetching it again will hit the backend (and the lock/fetch logic, but it's already in the backend)
+      await tempHandler.fetch('key-0', async () => -1);
+      expect(backendSpy).toHaveBeenCalledWith('key-0');
+
+      backendSpy.mockClear();
+
+      // Key 1004 should be in L1 cache, so fetching it again should NOT hit the backend
+      await tempHandler.fetch('key-1004', async () => -1);
+      expect(backendSpy).not.toHaveBeenCalled();
+
+      if (tempHandler.destroy) {
+        tempHandler.destroy();
+      }
     });
   });
 


### PR DESCRIPTION
💡 What: Introduced a `MAX_L1_CACHE_SIZE` of 1000 items and implemented an O(1) FIFO eviction policy using `Map.prototype.keys().next().value` to manage the L1 in-memory cache safely.
🎯 Why: Without a size limit, the in-memory `Map` could grow indefinitely when handling requests with dynamically generated, distinct cache keys. This risks memory exhaustion leading to degraded application performance due to excessive garbage collection, or potentially causing application crashes from Out-Of-Memory (OOM) errors (a form of Denial of Service vector).
📊 Impact: Prevents memory leaks on the L1 cache. The application's memory usage is now strictly bounded for in-memory caching overhead.
🔬 Measurement: Verify by examining test suite execution and confirming no memory-related regression. Long-running profiles on heavily trafficked endpoints with randomized cache keys will confirm bounded memory allocation.

---
*PR created automatically by Jules for task [934691618872139084](https://jules.google.com/task/934691618872139084) started by @suranig*