### PR TITLE
🧹 Remove dead cleanup method in MemoryCacheBackend

### DIFF
--- a/src/backends/memory.ts
+++ b/src/backends/memory.ts
@@ -80,25 +80,4 @@ export class MemoryCacheBackend<T = unknown> implements CacheBackend<T> {
     this.store.clear();
     this.locks.clear();
   }
-
-  /**
-   * Clean up expired entries (useful for memory management).
-   */
-  cleanup(): void {
-    const now = Date.now();
-
-    // Clean up expired cache entries
-    for (const [key, item] of this.store.entries()) {
-      if (item.expiresAt && item.expiresAt <= now) {
-        this.store.delete(key);
-      }
-    }
-
-    // Clean up expired locks
-    for (const [key, lock] of this.locks.entries()) {
-      if (lock.expiresAt <= now) {
-        this.locks.delete(key);
-      }
-    }
-  }
 }

--- a/test/backends/memory.test.ts
+++ b/test/backends/memory.test.ts
@@ -77,19 +77,4 @@ describe('MemoryCacheBackend', () => {
     expect(await backend.get('key2')).toBeUndefined();
     expect(await backend.lock('lock1', 1)).toBe(true); // Lock should be cleared
   });
-
-  it('should cleanup expired entries', async () => {
-    await backend.set('expired-key', 42, { ttl: 0.1 });
-    await backend.lock('expired-lock', 0.1);
-
-    // Wait for expiration
-    await new Promise((resolve) => setTimeout(resolve, 150));
-
-    // Manually trigger cleanup
-    backend.cleanup();
-
-    // Should not be able to acquire the expired lock
-    const lockAcquired = await backend.lock('expired-lock', 1);
-    expect(lockAcquired).toBe(true);
-  });
 });


### PR DESCRIPTION
Removed the unused `cleanup()` method in `MemoryCacheBackend` and cleaned up the corresponding test suite. This method was not part of the `CacheBackend` interface and was not utilized by the `CacheHandler` or other library components, making it dead code. In-memory expiration continues to be handled lazily during retrieval.

---
*PR created automatically by Jules for task [4811695324062394740](https://jules.google.com/task/4811695324062394740) started by @suranig*